### PR TITLE
Authentication abstraction, session-based implementation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check --color always
 
-      - name: Static analysis
+      - name: Tests all targets all features
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Static analysis
@@ -34,4 +34,3 @@ jobs:
 
       - name: Test doc
         run: cargo test --workspace --all-features --doc
-        continue-on-error: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Static analysis
         run: cargo test --workspace --all-targets --all-features
+
+      - name: Test doc
+        run: cargo test --workspace --all-features --doc
+        continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -56,6 +56,22 @@ dependencies = [
  "tokio-util",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "actix-identity"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b8ddc6f6a8b19c4016aaa13519968da9969bc3bc1c1c883cdb0f25dd6c8cf7"
+dependencies = [
+ "actix-service",
+ "actix-session",
+ "actix-utils",
+ "actix-web",
+ "derive_more 1.0.0",
+ "futures-core",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -122,6 +138,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-session"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe6976a74f34f1b6d07a6c05aadc0ed0359304a7781c367fa5b4029418db08f"
+dependencies = [
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "anyhow",
+ "derive_more 1.0.0",
+ "rand",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +184,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -199,6 +232,41 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
 
 [[package]]
 name = "ahash"
@@ -253,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +352,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -399,6 +479,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,7 +506,14 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
+ "aes-gcm",
+ "base64 0.20.0",
+ "hkdf",
+ "hmac",
  "percent-encoding",
+ "rand",
+ "sha2",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -454,7 +551,12 @@ dependencies = [
 name = "cosmian_http_client"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
+ "actix-identity",
+ "actix-session",
  "actix-web",
+ "anyhow",
+ "derive_more 0.99.18",
  "oauth2",
  "reqwest",
  "rustls",
@@ -500,7 +602,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -550,6 +662,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +690,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -719,6 +853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +898,24 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1019,6 +1181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1519,18 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1800,6 +1989,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2329,22 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/crate/config_utils/src/config_utils.rs
+++ b/crate/config_utils/src/config_utils.rs
@@ -5,14 +5,14 @@ use std::{
     path::PathBuf,
 };
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 #[cfg(target_os = "linux")]
 use tracing::info;
 use tracing::trace;
 
 #[cfg(target_os = "linux")]
 use crate::config_bail;
-use crate::error::{result::ConfigUtilsResultHelper, ConfigUtilsError};
+use crate::error::{ConfigUtilsError, result::ConfigUtilsResultHelper};
 
 /// Returns the path to the current user's home folder.
 ///

--- a/crate/config_utils/src/lib.rs
+++ b/crate/config_utils/src/lib.rs
@@ -1,4 +1,4 @@
-pub use config_utils::{get_default_conf_path, get_home_folder, location, ConfigUtils};
+pub use config_utils::{ConfigUtils, get_default_conf_path, get_home_folder, location};
 pub use error::ConfigUtilsError;
 
 mod config_utils;

--- a/crate/http_client/Cargo.toml
+++ b/crate/http_client/Cargo.toml
@@ -19,7 +19,6 @@ session = ["dep:actix-identity", "dep:actix-session"]
 actix-identity = { version =  "0.8.0", optional = true }
 actix-session = { version = "0.10.1", optional = true }
 actix-web = { version = "4.9.0", features = ["macros"] }
-anyhow = "1.0.93"
 derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }
 oauth2 = { version = "4.4", features = ["reqwest"] }
 reqwest = { version = "0.11", features = ["default", "json", "native-tls"] }
@@ -34,3 +33,4 @@ x509-cert = "0.2.5"
 
 [dev-dependencies]
 actix-http = "3.6.0"
+anyhow = "1.0.93"

--- a/crate/http_client/Cargo.toml
+++ b/crate/http_client/Cargo.toml
@@ -13,9 +13,14 @@ rust-version.workspace = true
 doctest = false
 
 [features]
+session = ["dep:actix-identity", "dep:actix-session"]
 
 [dependencies]
+actix-identity = { version =  "0.8.0", optional = true }
+actix-session = { version = "0.10.1", optional = true }
 actix-web = { version = "4.9.0", features = ["macros"] }
+anyhow = "1.0.93"
+derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }
 oauth2 = { version = "4.4", features = ["reqwest"] }
 reqwest = { version = "0.11", features = ["default", "json", "native-tls"] }
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
@@ -26,3 +31,6 @@ tokio = { version = "1.41", features = ["full"] }
 url = "2.5"
 webpki-roots = "0.22"
 x509-cert = "0.2.5"
+
+[dev-dependencies]
+actix-http = "3.6.0"

--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -31,9 +31,9 @@
 #[cfg(feature = "session")]
 pub mod session;
 
-use std::future::{ready, Ready};
+use std::future::{Ready, ready};
 
-use actix_web::{dev::Payload, FromRequest, HttpRequest};
+use actix_web::{FromRequest, HttpRequest, dev::Payload};
 use derive_more::{Deref, DerefMut};
 
 /// The `Authenticate` trait is used to authenticate a request.

--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -9,7 +9,9 @@
 //! ```rust,no_run
 //! use actix_web::{get, post, HttpRequest};
 //! use actix_web::web::Path;
-//! use cosmian_http_client::authentication::{Authenticated, Session};
+//! use cosmian_http_client::authentication::Authenticated;
+//! #[cfg(feature = "session")]
+//! use cosmian_http_client::authentication::session::Session;
 //!
 //! #[post("/login/<id>")]
 //! async fn login(id: Path<String>, request: HttpRequest) -> String {

--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -7,11 +7,11 @@
 //!
 //! # Examples
 //! ```rust,no_run
+//! # #[cfg(feature = "session")]
+//! # mod doc {
 //! use actix_web::{get, post, HttpRequest};
 //! use actix_web::web::Path;
-//! use cosmian_http_client::authentication::Authenticated;
-//! #[cfg(feature = "session")]
-//! use cosmian_http_client::authentication::session::Session;
+//! use cosmian_http_client::authentication::{Authenticated, session::Session};
 //!
 //! #[post("/login/<id>")]
 //! async fn login(id: Path<String>, request: HttpRequest) -> String {
@@ -26,6 +26,7 @@
 //! async fn hello(session: Authenticated<Session<String>>) -> String {
 //!     format!("Hello, {}!", session.data())
 //! }
+//! # }
 
 #[cfg(feature = "session")]
 pub mod session;

--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -1,0 +1,76 @@
+//! HTTP authentication for Actix Web.
+//!
+//! This module provides a set of utilities to authenticate HTTP requests through `actix-web`
+//! extractors.
+//! The available authenticators are:
+//! - `Session`: A session-based authenticator that uses a cookie to store an identifier.
+//!
+//! # Examples
+//! ```rust,no_run
+//! use actix_web::{get, post, HttpRequest};
+//! use actix_web::web::Path;
+//! use cosmian_http_client::authentication::{Authenticated, Session};
+//!
+//! #[post("/login/<id>")]
+//! async fn login(id: Path<String>, request: HttpRequest) -> String {
+//!    // Create a session with the given identifier
+//!    match Session::start(&request, id.into_inner()) {
+//!       Ok(session) => format!("Logged in as {}", session.data()),
+//!       Err(_) => "Failed to log in".to_string(),
+//!    }
+//! }
+//!
+//! #[get("/")]
+//! async fn hello(session: Authenticated<Session<String>>) -> String {
+//!     format!("Hello, {}!", session.data())
+//! }
+
+#[cfg(feature = "session")]
+pub mod session;
+
+use std::future::{ready, Ready};
+
+use actix_web::{dev::Payload, FromRequest, HttpRequest};
+use derive_more::{Deref, DerefMut};
+
+/// The `Authenticate` trait is used to authenticate a request.
+///
+/// The `Output` associated type maybe be used to extract any useful information about the
+/// authenticated request.
+pub trait Authenticate {
+    /// Any information about the authenticated request.
+    type Output;
+    type Error;
+
+    /// Authenticate a request.
+    ///
+    /// # Errors
+    /// Returns an error if the request could not be authenticated somehow.
+    fn authenticate(request: &HttpRequest) -> Result<Self::Output, Self::Error>;
+}
+
+/// An extractor for an authenticated request.
+#[derive(Deref, DerefMut)]
+pub struct Authenticated<T: Authenticate>(T::Output);
+
+impl<T: Authenticate> Authenticated<T> {
+    /// Unwrap into the authenticator output.
+    pub fn into_inner(self) -> T::Output {
+        self.0
+    }
+}
+
+impl<T: Authenticate> FromRequest for Authenticated<T>
+where
+    T::Error: Into<actix_web::Error>,
+{
+    type Error = T::Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        match T::authenticate(req) {
+            Ok(value) => ready(Ok(Self(value))),
+            Err(error) => ready(Err(error)),
+        }
+    }
+}

--- a/crate/http_client/src/authentication/session.rs
+++ b/crate/http_client/src/authentication/session.rs
@@ -4,14 +4,14 @@
 //! so it is required to have them in dependencies and setup in the application beforehand.
 
 use actix_identity::{
-    error::{GetIdentityError, LoginError},
     Identity, IdentityExt,
+    error::{GetIdentityError, LoginError},
 };
 use actix_web::{
-    body::BoxBody, error::ResponseError, http::header::ContentType, http::StatusCode, HttpMessage,
-    HttpRequest, HttpResponse, HttpResponseBuilder,
+    HttpMessage, HttpRequest, HttpResponse, HttpResponseBuilder, body::BoxBody,
+    error::ResponseError, http::StatusCode, http::header::ContentType,
 };
-use serde::{de::DeserializeOwned, ser::SerializeStruct, Serialize, Serializer};
+use serde::{Serialize, Serializer, de::DeserializeOwned, ser::SerializeStruct};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 
@@ -142,12 +142,13 @@ mod tests {
     use actix_identity::IdentityMiddleware;
     use actix_session::SessionMiddleware;
     use actix_web::{
+        App, HttpResponse, Responder,
         body::MessageBody,
         cookie::Key,
         dev::{Service, ServiceResponse},
         get,
         http::{Method, StatusCode},
-        post, test, App, HttpResponse, Responder,
+        post, test,
     };
 
     #[post("/start_session")]
@@ -170,8 +171,8 @@ mod tests {
         HttpResponse::Ok()
     }
 
-    async fn create_app(
-    ) -> impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>
+    async fn create_app()
+    -> impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>
     {
         test::init_service(
             App::new()

--- a/crate/http_client/src/authentication/session.rs
+++ b/crate/http_client/src/authentication/session.rs
@@ -1,0 +1,221 @@
+//! Session authenticator.
+//!
+//! This authenticator is built on top of the `actix_identity` and `actix_session` crates
+//! so it is required to have them in dependencies and setup in the application beforehand.
+
+use actix_identity::{
+    error::{GetIdentityError, LoginError},
+    Identity, IdentityExt,
+};
+use actix_web::{
+    body::BoxBody, error::ResponseError, http::header::ContentType, http::StatusCode, HttpMessage,
+    HttpRequest, HttpResponse, HttpResponseBuilder,
+};
+use serde::{de::DeserializeOwned, ser::SerializeStruct, Serialize, Serializer};
+use serde_json::Error as SerdeError;
+use thiserror::Error;
+
+use super::Authenticate;
+
+/// The error type that can occur during an authentication by session.
+#[derive(Debug, Error)]
+pub enum SessionError {
+    #[error("Unauthenticated")]
+    Unauthenticated,
+    #[error("Authentication failure: {0}")]
+    AuthenticationFailure(#[from] LoginError),
+    #[error("Corrupted data: {0}")]
+    ParseError(#[from] SerdeError),
+}
+
+impl From<GetIdentityError> for SessionError {
+    fn from(_error: GetIdentityError) -> Self {
+        Self::Unauthenticated
+    }
+}
+
+impl Serialize for SessionError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Error", 2)?;
+
+        state.serialize_field("error", &self.to_string())?;
+        state.serialize_field("code", &self.status_code().as_u16())?;
+
+        state.end()
+    }
+}
+
+impl ResponseError for SessionError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Unauthenticated => StatusCode::UNAUTHORIZED,
+            Self::AuthenticationFailure(_) | Self::ParseError(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        let status_code = self.status_code();
+
+        HttpResponseBuilder::new(status_code)
+            .content_type(ContentType::json())
+            .json(self)
+    }
+}
+
+pub struct Session<T: Serialize + DeserializeOwned> {
+    data: T,
+    identity: Option<Identity>,
+}
+
+impl<T: Serialize + DeserializeOwned> Session<T> {
+    /// Start a new session.
+    ///
+    /// # Arguments
+    /// * `request` - The request to start the session for.
+    /// * `data` -The data to attach to the session.
+    ///
+    /// # Errors
+    /// This method can fail if:
+    /// - The data cannot be serialized.
+    /// - The session cannot be started.
+    pub fn start(request: &HttpRequest, data: T) -> Result<Self, SessionError> {
+        let identity = Identity::login(&request.extensions(), serde_json::to_string(&data)?)?;
+
+        Ok(Self {
+            data,
+            identity: Some(identity),
+        })
+    }
+
+    /// Stop the session forcefully.
+    ///
+    /// Any further requests will be unauthenticated.
+    pub fn force_stop(&mut self) {
+        if let Some(identity) = self.identity.take() {
+            identity.logout();
+        }
+    }
+
+    /// Indicate if the session is stopped.
+    pub const fn is_stopped(&self) -> bool {
+        self.identity.is_none()
+    }
+
+    /// Get data attached to the session.
+    #[must_use]
+    pub const fn data(&self) -> &T {
+        &self.data
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> Authenticate for Session<T> {
+    type Output = Self;
+    type Error = SessionError;
+
+    fn authenticate(request: &HttpRequest) -> Result<Self::Output, Self::Error> {
+        request
+            .get_identity()
+            .map_err(Into::into)
+            .and_then(|identity| {
+                let data = serde_json::from_str(identity.id()?.as_str())?;
+
+                Ok(Self {
+                    data,
+                    identity: Some(identity),
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authentication::Authenticated;
+    use crate::tests::session_store::MockSessionStore;
+
+    use actix_http::Request;
+    use actix_identity::IdentityMiddleware;
+    use actix_session::SessionMiddleware;
+    use actix_web::{
+        body::MessageBody,
+        cookie::Key,
+        dev::{Service, ServiceResponse},
+        get,
+        http::{Method, StatusCode},
+        post, test, App, HttpResponse, Responder,
+    };
+
+    #[post("/start_session")]
+    async fn start_session(request: HttpRequest) -> impl Responder {
+        let status_code = Session::start(&request, "user_id".to_owned())
+            .map_or(StatusCode::INTERNAL_SERVER_ERROR, |_| StatusCode::OK);
+
+        HttpResponse::new(status_code)
+    }
+
+    #[get("/session_data")]
+    async fn session_data(session: Authenticated<Session<String>>) -> impl Responder {
+        HttpResponse::Ok().json(session.data())
+    }
+
+    #[post("/stop_session")]
+    async fn stop_session(mut session: Authenticated<Session<String>>) -> impl Responder {
+        session.force_stop();
+
+        HttpResponse::Ok()
+    }
+
+    async fn create_app(
+    ) -> impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>
+    {
+        test::init_service(
+            App::new()
+                .wrap(IdentityMiddleware::default())
+                .wrap(SessionMiddleware::new(
+                    MockSessionStore::default(),
+                    Key::generate(),
+                ))
+                .service(start_session)
+                .service(session_data)
+                .service(stop_session),
+        )
+        .await
+    }
+
+    #[actix_web::test]
+    async fn authentication_by_session() {
+        let app = create_app().await;
+
+        let request = test::TestRequest::post().uri("/start_session").to_request();
+        let result = test::call_service(&app, request).await;
+        assert!(result.status().is_success());
+
+        let cookies = result.response().cookies().collect::<Vec<_>>();
+        assert_eq!(cookies.len(), 1);
+
+        #[allow(clippy::indexing_slicing)]
+        let cookie = &cookies[0];
+
+        let tests = [
+            (Method::GET, "/session_data", StatusCode::OK),
+            (Method::POST, "/stop_session", StatusCode::OK),
+            (Method::GET, "/session_data", StatusCode::UNAUTHORIZED),
+            (Method::POST, "/stop_session", StatusCode::UNAUTHORIZED),
+        ];
+
+        for (method, uri, status_code) in tests {
+            let request = test::TestRequest::default()
+                .method(method)
+                .uri(uri)
+                .cookie(cookie.clone())
+                .to_request();
+            let result = test::call_service(&app, request).await;
+            assert_eq!(result.status(), status_code, "Failed for uri: {uri}");
+        }
+    }
+}

--- a/crate/http_client/src/certificate_verifier.rs
+++ b/crate/http_client/src/certificate_verifier.rs
@@ -1,8 +1,8 @@
 use std::{sync::Arc, time::SystemTime};
 
 use rustls::{
-    client::{ServerCertVerified, ServerCertVerifier},
     Certificate, Error as RustTLSError, ServerName,
+    client::{ServerCertVerified, ServerCertVerifier},
 };
 
 /// A TLS verifier adding the ability to match the leaf certificate with a

--- a/crate/http_client/src/http_client.rs
+++ b/crate/http_client/src/http_client.rs
@@ -6,20 +6,20 @@ use std::{
 };
 
 use reqwest::{
-    header::{HeaderMap, HeaderValue},
     Client, ClientBuilder, Identity,
+    header::{HeaderMap, HeaderValue},
 };
-use rustls::{client::WebPkiVerifier, Certificate};
+use rustls::{Certificate, client::WebPkiVerifier};
 use serde::{Deserialize, Serialize};
 use x509_cert::{
-    der::{DecodePem, Encode},
     Certificate as X509Certificate,
+    der::{DecodePem, Encode},
 };
 
 use crate::{
-    certificate_verifier::{LeafCertificateVerifier, NoVerifier},
-    error::{result::HttpClientResultHelper, HttpClientError},
     Oauth2LoginConfig,
+    certificate_verifier::{LeafCertificateVerifier, NoVerifier},
+    error::{HttpClientError, result::HttpClientResultHelper},
 };
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]

--- a/crate/http_client/src/lib.rs
+++ b/crate/http_client/src/lib.rs
@@ -57,9 +57,9 @@ pub use error::HttpClientError;
 pub use http_client::{HttpClient, HttpClientConfig};
 pub use login::{LoginState, Oauth2LoginConfig};
 
+pub mod authentication;
 mod certificate_verifier;
 mod error;
 mod http_client;
 mod login;
-pub mod authentication;
 pub mod tests;

--- a/crate/http_client/src/lib.rs
+++ b/crate/http_client/src/lib.rs
@@ -61,3 +61,5 @@ mod certificate_verifier;
 mod error;
 mod http_client;
 mod login;
+pub mod authentication;
+pub mod tests;

--- a/crate/http_client/src/lib.rs
+++ b/crate/http_client/src/lib.rs
@@ -62,4 +62,5 @@ mod certificate_verifier;
 mod error;
 mod http_client;
 mod login;
+#[cfg(test)]
 pub mod tests;

--- a/crate/http_client/src/login.rs
+++ b/crate/http_client/src/login.rs
@@ -5,24 +5,22 @@ use std::{
 };
 
 use actix_web::{
-    get,
+    App, HttpResponse, HttpServer, get,
     web::{self, Data},
-    App, HttpResponse, HttpServer,
 };
 use oauth2::{
-    basic::BasicClient,
-    http::{
-        self,
-        header::{ACCEPT, CONTENT_TYPE},
-        HeaderMap, HeaderValue, StatusCode,
-    },
     AuthUrl, ClientId, ClientSecret, CsrfToken, HttpRequest, PkceCodeChallenge, PkceCodeVerifier,
     RedirectUrl, Scope, TokenUrl,
+    basic::BasicClient,
+    http::{
+        self, HeaderMap, HeaderValue, StatusCode,
+        header::{ACCEPT, CONTENT_TYPE},
+    },
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::{error::result::HttpClientResult, http_client_bail, HttpClientError};
+use crate::{HttpClientError, error::result::HttpClientResult, http_client_bail};
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 pub struct Oauth2LoginConfig {

--- a/crate/http_client/src/tests.rs
+++ b/crate/http_client/src/tests.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "session")]
+pub mod session_store;

--- a/crate/http_client/src/tests/session_store.rs
+++ b/crate/http_client/src/tests/session_store.rs
@@ -48,13 +48,15 @@ impl SessionStore for MockSessionStore {
     ) -> Result<SessionKey, UpdateError> {
         key_to_index(&session_key)
             .map_err(UpdateError::Other)
-            .and_then(|i| match self.data.borrow_mut().get_mut(i) {
-                Some(data) => {
-                    *data = session_state;
+            .and_then(|i| {
+                self.data.borrow_mut().get_mut(i).map_or_else(
+                    || Err(UpdateError::Other(Error::msg("No such key"))),
+                    |data| {
+                        *data = session_state;
 
-                    Ok(session_key)
-                }
-                None => Err(UpdateError::Other(Error::msg("No such key"))),
+                        Ok(session_key)
+                    },
+                )
             })
     }
 

--- a/crate/http_client/src/tests/session_store.rs
+++ b/crate/http_client/src/tests/session_store.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+use std::{cell::RefCell, collections::HashMap};
+
+use actix_session::storage::{LoadError, SaveError, SessionKey, SessionStore, UpdateError};
+use actix_web::cookie::time::Duration;
+use anyhow::Error;
+
+
+/// A simple in-memory session store for testing purposes.
+#[derive(Default)]
+pub struct MockSessionStore {
+    data: RefCell<Vec<HashMap<String, String>>>,
+}
+
+/// Convert a session key to an index into the data store.
+fn key_to_index(session_key: &SessionKey) -> Result<usize, Error> {
+    usize::from_str(session_key.as_ref()).map_err(Into::into)
+}
+
+impl SessionStore for MockSessionStore {
+    async fn load(
+        &self,
+        session_key: &SessionKey,
+    ) -> Result<Option<HashMap<String, String>>, LoadError> {
+        key_to_index(session_key)
+            .map(|i| self.data.borrow().get(i).cloned())
+            .map_err(LoadError::Deserialization)
+    }
+
+    async fn save(
+        &self,
+        session_state: HashMap<String, String>,
+        _ttl: &Duration,
+    ) -> Result<SessionKey, SaveError> {
+        let key = SessionKey::try_from(self.data.borrow().len().to_string())
+            .map_err(Error::from)
+            .map_err(SaveError::Serialization)?;
+
+        self.data.borrow_mut().push(session_state);
+
+        Ok(key)
+    }
+
+    async fn update(
+        &self,
+        session_key: SessionKey,
+        session_state: HashMap<String, String>,
+        _ttl: &Duration,
+    ) -> Result<SessionKey, UpdateError> {
+        key_to_index(&session_key)
+            .map_err(UpdateError::Other)
+            .and_then(|i| match self.data.borrow_mut().get_mut(i) {
+                Some(data) => {
+                    *data = session_state;
+
+                    Ok(session_key)
+                }
+                None => Err(UpdateError::Other(Error::msg("No such key"))),
+            })
+    }
+
+    async fn update_ttl(&self, _session_key: &SessionKey, _ttl: &Duration) -> Result<(), Error> {
+        unimplemented!();
+    }
+
+    async fn delete(&self, session_key: &SessionKey) -> Result<(), Error> {
+        match key_to_index(session_key)? {
+            i if i < self.data.borrow().len() => {
+                self.data.borrow_mut().remove(i);
+
+                Ok(())
+            }
+            _ => Err(Error::msg("No such key")),
+        }
+    }
+}

--- a/crate/http_client/src/tests/session_store.rs
+++ b/crate/http_client/src/tests/session_store.rs
@@ -5,7 +5,6 @@ use actix_session::storage::{LoadError, SaveError, SessionKey, SessionStore, Upd
 use actix_web::cookie::time::Duration;
 use anyhow::Error;
 
-
 /// A simple in-memory session store for testing purposes.
 #[derive(Default)]
 pub struct MockSessionStore {

--- a/crate/logger/src/log_utils.rs
+++ b/crate/logger/src/log_utils.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use tracing_subscriber::{
-    layer::SubscriberExt, registry, reload, util::SubscriberInitExt, EnvFilter,
+    EnvFilter, layer::SubscriberExt, registry, reload, util::SubscriberInitExt,
 };
 
 static LOG_INIT: Once = Once::new();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.83"
 components = ["rustfmt"]


### PR DESCRIPTION
# Description

This PR introduces a way to protect HTTP routes via an `Authenticated<T>` type, which is basically an `actix_web` extractor and use internally an authenticator (session, JWT, ...).

This PR contains two main type/trait:
- `Authenticated<T>`, use an `Authenticate` trait implementator internally to authenticate incoming request on protected HTTP route.
- `Authenticate` trait must be implemented by any authenticator.

This PR also adds `MockSessionStore`, which is a in-memory session store, to ease UT writing and get rid of Redis dependency in test environment (at least for session management).

**Note that I put the session-based authentication in a feature.** 
