### PR TITLE
`EitherExt` trait to handle `Authenticate` implementation in a easy way

### DIFF
--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -27,7 +27,9 @@
 //!     format!("Hello, {}!", session.data())
 //! }
 //! # }
+//! ```
 
+pub mod either;
 #[cfg(feature = "session")]
 pub mod session;
 
@@ -36,11 +38,13 @@ use std::future::{Ready, ready};
 use actix_web::{FromRequest, HttpRequest, dev::Payload};
 use derive_more::{Deref, DerefMut};
 
+pub use either::EitherExt;
+
 /// The `Authenticate` trait is used to authenticate a request.
 ///
 /// The `Output` associated type maybe be used to extract any useful information about the
 /// authenticated request.
-pub trait Authenticate {
+pub trait Authenticate: Sized {
     /// Any information about the authenticated request.
     type Output;
     type Error;
@@ -49,16 +53,19 @@ pub trait Authenticate {
     ///
     /// # Errors
     /// Returns an error if the request could not be authenticated somehow.
-    fn authenticate(request: &HttpRequest) -> Result<Self::Output, Self::Error>;
+    fn authenticate(request: &HttpRequest) -> Result<Self, Self::Error>;
+
+    /// Extract the data from the authenticated request.
+    fn data(&self) -> &Self::Output;
 }
 
 /// An extractor for an authenticated request.
 #[derive(Deref, DerefMut)]
-pub struct Authenticated<T: Authenticate>(T::Output);
+pub struct Authenticated<T: Authenticate>(T);
 
 impl<T: Authenticate> Authenticated<T> {
     /// Unwrap into the authenticator output.
-    pub fn into_inner(self) -> T::Output {
+    pub fn into_inner(self) -> T {
         self.0
     }
 }

--- a/crate/http_client/src/authentication.rs
+++ b/crate/http_client/src/authentication.rs
@@ -11,7 +11,7 @@
 //! # mod doc {
 //! use actix_web::{get, post, HttpRequest};
 //! use actix_web::web::Path;
-//! use cosmian_http_client::authentication::{Authenticated, session::Session};
+//! use cosmian_http_client::authentication::{Authenticated, Authenticate, session::Session};
 //!
 //! #[post("/login/<id>")]
 //! async fn login(id: Path<String>, request: HttpRequest) -> String {

--- a/crate/http_client/src/authentication/either.rs
+++ b/crate/http_client/src/authentication/either.rs
@@ -11,18 +11,18 @@
 //! use actix_web::web::Path;
 //! use cosmian_http_client::authentication::{Authenticated, Authenticate, EitherExt, session::Session};
 //!
-//! struct Admin;
+//! struct Admin(String);
 //!
 //! impl Authenticate for Admin {
-//!    type Output = str;
+//!    type Output = String;
 //!    type Error = Error;
 //!
 //!    fn authenticate(request: &HttpRequest) -> Result<Self, Self::Error> {
-//!         Ok(Self)
+//!         Ok(Self("admin".to_owned()))
 //!    }
 //!
 //!    fn data(&self) -> &Self::Output {
-//!         "admin"
+//!         &self.0
 //!    }
 //! }
 //!

--- a/crate/http_client/src/authentication/either.rs
+++ b/crate/http_client/src/authentication/either.rs
@@ -1,0 +1,147 @@
+//! Extensions for `actix_web::Either`.
+//!
+//! This module provides a trait that extends `actix_web::Either` to handle `Authenticate` implementation
+//! in a more convenient way.
+//!
+//! # Example
+//! ```rust,no_run
+//! # #[cfg(feature = "session")]
+//! # mod doc {
+//! use actix_web::{get, post, HttpRequest, Either, Error};
+//! use actix_web::web::Path;
+//! use cosmian_http_client::authentication::{Authenticated, Authenticate, EitherExt, session::Session};
+//!
+//! struct Admin;
+//!
+//! impl Authenticate for Admin {
+//!    type Output = str;
+//!    type Error = Error;
+//!
+//!    fn authenticate(request: &HttpRequest) -> Result<Self, Self::Error> {
+//!         Ok(Self)
+//!    }
+//!
+//!    fn data(&self) -> &Self::Output {
+//!         "admin"
+//!    }
+//! }
+//!
+//! #[post("/")]
+//! async fn protected_route(authentication: Either<Authenticated<Session<String>>, Authenticated<Admin>>) -> String {
+//!    // it will get session data first and fallback to admin data if the session authentication fails somehow
+//!    format!("{}", authentication.data())
+//! }
+//! # }
+//! ```
+
+use actix_web::Either;
+
+use super::{Authenticate, Authenticated};
+
+/// An extension trait for `actix_web::Either`.
+pub trait EitherExt<T> {
+    /// Returns a reference to the data of either side.
+    fn data(&self) -> &T;
+}
+
+impl<L, R, T> EitherExt<T> for Either<Authenticated<L>, Authenticated<R>>
+where
+    L: Authenticate<Output = T>,
+    R: Authenticate<Output = T>,
+{
+    fn data(&self) -> &T {
+        match self {
+            Self::Left(value) => value.data(),
+            Self::Right(value) => value.data(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_http::Request;
+    use actix_web::{
+        App, Either, Error, HttpRequest, HttpResponse, Responder,
+        body::MessageBody,
+        dev::{Service, ServiceResponse},
+        error, get, test,
+        web::Bytes,
+    };
+
+    use super::EitherExt;
+    use crate::authentication::{Authenticate, Authenticated};
+
+    macro_rules! impl_authenticate {
+        ($($name:ident),+) => {$(
+            struct $name(String);
+
+            impl Authenticate for $name {
+                type Output = String;
+                type Error = Error;
+
+                fn authenticate(request: &HttpRequest) -> Result<Self, Self::Error> {
+                    let value = request
+                        .headers()
+                        .get(stringify!($name))
+                        .ok_or(error::ErrorUnauthorized("unauthorized"))?
+                        .to_str()
+                        .map_err(|e| error::ErrorUnauthorized(e))?
+                        .to_owned();
+
+                     Ok(Self(value))
+                }
+
+                fn data(&self) -> &Self::Output {
+                    &self.0
+                }
+            }
+        )+};
+    }
+
+    impl_authenticate!(A, B);
+
+    #[get("/")]
+    async fn get_data(
+        authentication: Either<Authenticated<A>, Authenticated<B>>,
+    ) -> impl Responder {
+        HttpResponse::Ok().body(authentication.data().to_string())
+    }
+
+    async fn create_app()
+    -> impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = actix_web::Error>
+    {
+        test::init_service(App::new().service(get_data)).await
+    }
+
+    #[actix_web::test]
+    async fn either_authentication() {
+        let app = create_app().await;
+
+        let request = test::TestRequest::get()
+            .uri("/")
+            .insert_header(("A", "testA"))
+            .to_request();
+
+        let result = test::call_service(&app, request).await;
+        assert_eq!(result.status(), 200);
+
+        let body = test::read_body(result).await;
+        assert_eq!(body, Bytes::from_static(b"testA"));
+
+        let request = test::TestRequest::get()
+            .uri("/")
+            .insert_header(("B", "testB"))
+            .to_request();
+
+        let result = test::call_service(&app, request).await;
+        assert!(result.status().is_success());
+
+        let body = test::read_body(result).await;
+        assert_eq!(body, Bytes::from_static(b"testB"));
+
+        let request = test::TestRequest::get().uri("/").to_request();
+
+        let result = test::call_service(&app, request).await;
+        assert!(result.status().is_client_error());
+    }
+}

--- a/crate/http_client/src/authentication/session.rs
+++ b/crate/http_client/src/authentication/session.rs
@@ -105,19 +105,13 @@ impl<T: Serialize + DeserializeOwned> Session<T> {
     pub const fn is_stopped(&self) -> bool {
         self.identity.is_none()
     }
-
-    /// Get data attached to the session.
-    #[must_use]
-    pub const fn data(&self) -> &T {
-        &self.data
-    }
 }
 
 impl<T: Serialize + DeserializeOwned> Authenticate for Session<T> {
-    type Output = Self;
+    type Output = T;
     type Error = SessionError;
 
-    fn authenticate(request: &HttpRequest) -> Result<Self::Output, Self::Error> {
+    fn authenticate(request: &HttpRequest) -> Result<Self, Self::Error> {
         request
             .get_identity()
             .map_err(Into::into)
@@ -129,6 +123,11 @@ impl<T: Serialize + DeserializeOwned> Authenticate for Session<T> {
                     identity: Some(identity),
                 })
             })
+    }
+
+    #[must_use]
+    fn data(&self) -> &Self::Output {
+        &self.data
     }
 }
 


### PR DESCRIPTION
# Description

This PR introduces a new trait `EitherExt` which basically has one single method `data(&self) -> &T`.
This extension trait allows to get either left/right authenticated data, akin to `Either::into_inner<T>` for `Json` and `Form` type, without having to deconstruct the enumeration (which is the case most time).