### PR TITLE
fix: config utils trait

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,17 +8,20 @@ on:
 jobs:
   audit:
     name: Security Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   lint:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.83.0
         with:
           components: rustfmt, clippy
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.cargo_check
 /target
 /env
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
     rev: v1.0.32
     hooks:
       # - id: nightly-cargo-format
-      - id: stable-cargo-format
+      - id: cargo-format
       # - id: dprint-toml-fix
       # - id: cargo-upgrade
       # - id: cargo-update
@@ -136,7 +136,7 @@ repos:
       - id: clippy-autofix-all-targets
       - id: clippy-all-targets-all-features
       - id: clippy-all-targets
-      - id: stable-cargo-format # in last du to clippy fixes
+      - id: cargo-format # in last du to clippy fixes
 
   - repo: https://github.com/EmbarkStudios/cargo-deny
     rev: 0.16.1 # choose your preferred tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,9 +2354,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/crate/config_utils/Cargo.toml
+++ b/crate/config_utils/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 base64 = "0.21"
 serde = { workspace = true }
 serde_json = { workspace = true }
-toml = "0.8"
 thiserror = { workspace = true }
+toml = "0.8"
 tracing = { workspace = true }
 url = "2.5"

--- a/crate/config_utils/src/error/mod.rs
+++ b/crate/config_utils/src/error/mod.rs
@@ -15,8 +15,8 @@ pub enum ConfigUtilsError {
     #[error("{0}")]
     Default(String),
 
-    #[error("Not Supported: {0}")]
-    NotSupported(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
 
     #[error("Unexpected Error: {0}")]
     UnexpectedError(String),

--- a/crate/config_utils/src/lib.rs
+++ b/crate/config_utils/src/lib.rs
@@ -3,3 +3,6 @@ pub use error::ConfigUtilsError;
 
 mod config_utils;
 mod error;
+
+#[cfg(test)]
+pub mod tests;

--- a/crate/config_utils/src/tests.rs
+++ b/crate/config_utils/src/tests.rs
@@ -1,0 +1,77 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::*;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+const TEST_FILE: &str = "/bin/cat";
+#[cfg(windows)]
+const TEST_FILE: &str = "C:\\Windows\\System32\\cmd.exe";
+
+#[test]
+fn test_location() {
+    // Test with CLI argument
+    let conf_path = PathBuf::from(TEST_FILE);
+    let result = location(
+        Some(conf_path.clone()),
+        "TEST_CONF",
+        "config/default.toml",
+        "/etc/default.toml",
+    );
+    assert_eq!(result.unwrap(), conf_path);
+
+    // Test with environment variable
+    env::set_var("TEST_CONF", TEST_FILE);
+    let result = location(
+        None,
+        "TEST_CONF",
+        "config/default.toml",
+        "/etc/default.toml",
+    );
+    assert_eq!(result.unwrap(), PathBuf::from(TEST_FILE));
+
+    // Test with default path
+    env::remove_var("TEST_CONF");
+    env::set_var("HOME", "/fake/home");
+    let result = location(
+        None,
+        "TEST_CONF",
+        "config/default.toml",
+        "/etc/default.toml",
+    );
+    assert_eq!(
+        result.unwrap(),
+        PathBuf::from("/fake/home/config/default.toml")
+    );
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct TestConfig {
+    key: String,
+}
+
+impl ConfigUtils for TestConfig {}
+
+#[test]
+fn test_config_utils_save_and_load() {
+    let conf_path = "test_config.toml";
+    let config = TestConfig {
+        key: "value".to_string(),
+    };
+
+    // Test saving to TOML
+    config.to_toml(conf_path).unwrap();
+    let loaded_config = TestConfig::from_toml(conf_path).unwrap();
+    assert_eq!(config.key, loaded_config.key);
+
+    // Test saving to JSON
+    config.to_json(conf_path).unwrap();
+    let loaded_config = TestConfig::from_json(conf_path).unwrap();
+    assert_eq!(config.key, loaded_config.key);
+
+    // Clean up
+    fs::remove_file(conf_path).unwrap();
+}

--- a/crate/http_client/Cargo.toml
+++ b/crate/http_client/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 session = ["dep:actix-identity", "dep:actix-session"]
 
 [dependencies]
-actix-identity = { version =  "0.8.0", optional = true }
+actix-identity = { version = "0.8.0", optional = true }
 actix-session = { version = "0.10.1", optional = true }
 actix-web = { version = "4.9.0", features = ["macros"] }
 derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }


### PR DESCRIPTION
Changes on crate `config_utils`:
- simplify trait usage by replacing argument type from `PathBuf` to `str`
- rename error `NotSupported` to `NotFound`
- add tests

Changes on `Cargo.lock`:
- bump url crate to 2.5.4 (for `cargo deny` security requirements)