### PR TITLE
fix(logger): gate tracing-appender behind cfg(not(wasm32)) for WASM compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.2] - 2026-06-19
+
+### 🐛 Bug Fixes
+
+- *(logger)* Gate tracing-appender behind cfg(not(wasm32)) for WASM compatibility
+
 ## [0.7.0] - 2025-12-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cosmian_config_utils"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_http_client"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "actix-http",
  "actix-identity",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_logger"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crate/config_utils", "crate/logger", "crate/http_client"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.71.0"
 authors = [

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To use these crates in your project, add them to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cosmian_http_client = { version = "0.7.0", features = ["session"] }
-cosmian_logger = "0.7.0"
-cosmian_config_utils = "0.7.0"
+cosmian_http_client = { version = "X.Y.Z", features = ["session"] }
+cosmian_logger = "X.Y.Z"
+cosmian_config_utils = "X.Y.Z"
 ```
 
 ## License

--- a/crate/logger/Cargo.toml
+++ b/crate/logger/Cargo.toml
@@ -44,13 +44,17 @@ opentelemetry_sdk = { version = "0.29", default-features = false, features = [
 syslog-tracing = { version = "0.3", optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
 tracing-opentelemetry = { version = "0.30", optional = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
   "ansi",
 ] }
+
+# tracing-appender uses the `symlink` crate for file rotation which does not compile on
+# wasm32-unknown-unknown. Gate it to native targets only.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-appender = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }

--- a/crate/logger/README.md
+++ b/crate/logger/README.md
@@ -11,7 +11,7 @@ A flexible logging crate that supports both synchronous and asynchronous environ
 
 ```toml
 [dependencies]
-cosmian_logger = { version = "0.7.0", features = ["full"] }
+cosmian_logger = { version = "X.Y.Z", features = ["full"] }
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ For applications that need OpenTelemetry and advanced features:
 
 ```toml
 [dependencies]
-cosmian_logger = { version = "0.7.0", features = ["full"] }
+cosmian_logger = { version = "X.Y.Z", features = ["full"] }
 ```
 
 ```rust
@@ -55,7 +55,7 @@ For synchronous applications that only need basic logging:
 
 ```toml
 [dependencies]
-cosmian_logger = "0.7.0"
+cosmian_logger = "X.Y.Z"
 ```
 
 ```rust
@@ -142,7 +142,7 @@ For more advanced use cases with OpenTelemetry integration, enable the `full` fe
 
 ```toml
 [dependencies]
-cosmian_logger = { version = "0.7.0", features = ["full"] }
+cosmian_logger = { version = "X.Y.Z", features = ["full"] }
 ```
 
 ```rust

--- a/crate/logger/src/lib.rs
+++ b/crate/logger/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! cosmian_logger = { version = "0.7.0", features = ["full"] }
+//! cosmian_logger = { version = "X.Y.Z", features = ["full"] }
 //! ```
 //!
 //! If you get an error like "no `TelemetryConfig` in the root", it means you

--- a/crate/logger/src/tracing.rs
+++ b/crate/logger/src/tracing.rs
@@ -85,6 +85,7 @@ pub struct LoggingGuards {
     tracer_provider: Option<SdkTracerProvider>,
     #[cfg(feature = "full")]
     meter_provider: Option<SdkMeterProvider>,
+    #[cfg(not(target_arch = "wasm32"))]
     rolling_appender_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
 }
 
@@ -317,6 +318,8 @@ fn tracing_init_(config: &TracingConfig) -> Result<LoggingGuards, LoggerError> {
     // File Logging Layer
     // ========================================
     // Logging the rolling file appender
+    // tracing-appender uses the `symlink` crate which is not available on wasm32.
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some((dir, name)) = &config.log_to_file {
         // create the logs directory if it does not exist
         if !dir.exists() {


### PR DESCRIPTION
## Problem

`tracing-appender` 0.2.5 added a dependency on the `symlink` crate for
log-file rotation. The `symlink` crate does not provide `symlink_file` /
`remove_symlink_file` on `wasm32-unknown-unknown`, causing compile errors
in any crate that depends on `cosmian_logger` and is compiled for WASM.

The issue surfaced in [Cosmian/kms#1020](https://github.com/Cosmian/kms/pull/1020)
where a `Cargo.lock` update pulled in `tracing-appender` 0.2.5.

## Fix

- Move `tracing-appender` from `[dependencies]` to
  `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` in `crate/logger/Cargo.toml`
- Gate `LoggingGuards::rolling_appender_guard` field behind `#[cfg(not(target_arch = "wasm32"))]`
- Gate the file-appender init block in `tracing_init_` behind `#[cfg(not(target_arch = "wasm32"))]`
- Bump version to `0.7.2`

## Impact

File logging (`log_to_file` config) remains fully functional on all native
targets. WASM builds no longer pull in `tracing-appender` or `symlink`.